### PR TITLE
Use latest version in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In the simplest case
 ```
 steps:
  - uses: actions/checkout@v2
- - uses: joergbrech/moxunit-action@v1.2.0
+ - uses: joergbrech/moxunit-action@v1
 ```
 
 runs all MOxUnit test cases found in this repository. A more complex use case could look like this:
@@ -65,7 +65,7 @@ runs all MOxUnit test cases found in this repository. A more complex use case co
 ```
 steps:
 - uses: actions/checkout@v2
-- uses: joergbrech/moxunit-action@v1.2.0
+ - uses: joergbrech/moxunit-action@v1
   with:
     tests: tests my_extra_testfile.m
     src: src thirdparty util

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: joergbrech/moxunit-action@v1.2.0
+      - uses: joergbrech/moxunit-action@v1
         with:
           tests: mySimpleTest1.m
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: joergbrech/moxunit-action@v1
+      - uses: joergbrech/moxunit-action@v1.2.0
         with:
           tests: mySimpleTest1.m
 ```
@@ -57,7 +57,7 @@ In the simplest case
 ```
 steps:
  - uses: actions/checkout@v2
- - uses: joergbrech/moxunit-action@master
+ - uses: joergbrech/moxunit-action@v1.2.0
 ```
 
 runs all MOxUnit test cases found in this repository. A more complex use case could look like this:
@@ -65,7 +65,7 @@ runs all MOxUnit test cases found in this repository. A more complex use case co
 ```
 steps:
 - uses: actions/checkout@v2
-- uses: joergbrech/moxunit-action@master
+- uses: joergbrech/moxunit-action@v1.2.0
   with:
     tests: tests my_extra_testfile.m
     src: src thirdparty util


### PR DESCRIPTION
just because things will fail if you just use `1.2` instead of `1.2.0` and this may confuse users